### PR TITLE
Add support for extended stack status

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='cfn_lambda_handler',
-    version='1.2.1',
+    version='1.3.0',
     packages=[ 'cfn_lambda_handler' ],
     install_requires=[ 'requests' ],
     provides=[ 'cfn_lambda_handler' ],
@@ -25,6 +25,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: ISC License (ISCL)',
     ],
 )


### PR DESCRIPTION
This PR adds the properties `StackStatus` and `StackStatusReason` to the `event` object passed to custom resource handlers.

This is useful for detecting if a stack is in a rollback state and taking appropriate action.